### PR TITLE
Add no_log: true to Pi-hole API authentication task

### DIFF
--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -186,6 +186,7 @@
       password: "{{ pihole_app_password }}"
     status_code: 200
   register: pihole_auth
+  no_log: true
 
 # --- DNS config (always applied) ---
 # pihole_upstream_dns and pihole_local_hosts in vars/main.yml are the source


### PR DESCRIPTION
Fixes #16.

## Summary
- Add `no_log: true` to the Pi-hole API auth task that POSTs `pihole_app_password`
- Prevents credential exposure in Ansible verbose output (`-vv`) and CI logs

## Test plan
- [ ] `ansible-playbook deploy_pihole.yml -vv` — password no longer visible in task output

🤖 Generated with [Claude Code](https://claude.com/claude-code)