### PR TITLE
Extract Plex ADVERTISE_IP to variable; switch to dynamic DNS hostname

### DIFF
--- a/deploy_apps.yml
+++ b/deploy_apps.yml
@@ -156,6 +156,13 @@
         state: present
         values_files:
           - /home/ansible/k8s/apps/plex/values.yml
+        values:
+          controllers:
+            plex:
+              containers:
+                app:
+                  env:
+                    ADVERTISE_IP: "{{ plex_advertise_ip }}"
       tags: [plex]
 
     # -------------------------------------------------------------------------

--- a/k8s/apps/plex/values.yml
+++ b/k8s/apps/plex/values.yml
@@ -31,9 +31,8 @@ controllers:
           NVIDIA_VISIBLE_DEVICES: all
           NVIDIA_DRIVER_CAPABILITIES: compute,video,utility
           VERSION: docker
-          # Advertise the correct external address so Plex registers properly with plex.tv.
-          # Must match the public IP:port forwarded by the router to any k3s node.
-          ADVERTISE_IP: "http://50.35.124.100:32400"
+          # ADVERTISE_IP is set via plex_advertise_ip in vars/vars.yml and injected
+          # by deploy_apps.yml at deploy time — not managed here.
           # PLEX_CLAIM is only needed for initial registration with plex.tv
           # Once configured, this can be removed from the values file
           PLEX_CLAIM:

--- a/vars/vars.yml
+++ b/vars/vars.yml
@@ -30,6 +30,9 @@ common_users:
 # Claude AI agent SSH public key (private key: ~/.ssh/claude_homelab)
 claude_ssh_pubkey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAID+aPw5R/OwsXml7FNuRm56ndZC9sY5gXieyJ8t5fIEp claude@homelab"
 
+# Plex — advertised address for plex.tv relay; uses dynamic DNS so IP churn doesn't require a redeploy
+plex_advertise_ip: "http://dynamic.alvani.me:32400"
+
 # DNS servers for static netplan config
 static_dns_servers:
   - 10.0.1.250  # Pi-hole


### PR DESCRIPTION
Fixes #15.

## Summary
- Add `plex_advertise_ip: "http://dynamic.alvani.me:32400"` to `vars/vars.yml`
- Inject via inline `values:` override in deploy_apps.yml (values_files are rsync'd as static YAML — Jinja2 doesn't expand there)
- Clear the hardcoded IP from `k8s/apps/plex/values.yml` with a note pointing at the var

Using the dynamic DNS hostname rather than the static IP so a future ISP IP change doesn't silently break Plex's advertised address.

## Test plan
- [ ] `ansible-playbook deploy_apps.yml --tags plex` completes without error
- [ ] `kubectl get pod -n plex` — pod restarts with new env var
- [ ] `kubectl exec -n plex <pod> -- env | grep ADVERTISE_IP` shows `http://dynamic.alvani.me:32400`
- [ ] Plex still reachable externally and connects to plex.tv

🤖 Generated with [Claude Code](https://claude.com/claude-code)