### PR TITLE
Restrict Docker daemon TCP listener to localhost

### DIFF
--- a/roles/docker/templates/docker.service.j2
+++ b/roles/docker/templates/docker.service.j2
@@ -11,8 +11,8 @@ Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
-ExecStart=/usr/bin/dockerd -H fd:// -H tcp://0.0.0.0:4243 --containerd=/run/containerd/containerd.sock
-#ExecStart=/usr/bin/dockerd -H tcp://0.0.0.0:4243 -H unix:///var/run/docker.sock
+ExecStart=/usr/bin/dockerd -H fd:// -H tcp://127.0.0.1:4243 --containerd=/run/containerd/containerd.sock
+#ExecStart=/usr/bin/dockerd -H tcp://127.0.0.1:4243 -H unix:///var/run/docker.sock
 ExecReload=/bin/kill -s HUP $MAINPID
 TimeoutSec=0
 RestartSec=2


### PR DESCRIPTION
Fixes #12.

## Summary
- Change `tcp://0.0.0.0:4243` → `tcp://127.0.0.1:4243` in `docker.service.j2`
- Traefik's Docker provider connects on the same host — no LAN exposure needed

## Test plan
- [ ] Re-run the docker role: `ansible-playbook deploy_aistack.yml --tags docker --limit 20-size.local` (or whichever playbook deploys this role)
- [ ] `ss -tlnp | grep 4243` on 20-size — should show `127.0.0.1:4243` only
- [ ] Traefik still routes correctly (no change to Traefik config needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)