### PR TITLE
Replace curl-pipe-to-shell k3s install with checksum-verified binary

### DIFF
--- a/roles/k3s/tasks/agent.yml
+++ b/roles/k3s/tasks/agent.yml
@@ -17,12 +17,16 @@
     group: root
     mode: '0644'
 
-- name: Install k3s agent
+- name: Download and verify k3s binary
+  ansible.builtin.include_tasks: install.yml
+
+- name: Set up k3s agent service
   ansible.builtin.shell: |
-    curl -sfL https://get.k3s.io \
-      | INSTALL_K3S_VERSION="{{ k3s_version }}" \
-        K3S_URL="https://{{ k3s_server_host }}:{{ k3s_server_port }}" \
-        K3S_TOKEN="{{ hostvars[k3s_server_host]['k3s_node_token'] }}" \
-        sh -s - agent
+    curl -sfL https://get.k3s.io | \
+      INSTALL_K3S_VERSION="{{ k3s_version }}" \
+      INSTALL_K3S_SKIP_DOWNLOAD=true \
+      K3S_URL="https://{{ k3s_server_host }}:{{ k3s_server_port }}" \
+      K3S_TOKEN="{{ hostvars[k3s_server_host]['k3s_node_token'] }}" \
+      sh -s - agent
   args:
-    creates: /usr/local/bin/k3s
+    creates: /etc/systemd/system/k3s-agent.service

--- a/roles/k3s/tasks/install.yml
+++ b/roles/k3s/tasks/install.yml
@@ -1,0 +1,57 @@
+---
+# Download k3s binary from GitHub releases, verify SHA256 checksum, and install.
+# Called by server.yml and agent.yml before running the install script.
+#
+# Uses INSTALL_K3S_SKIP_DOWNLOAD=true so the install script only sets up the
+# systemd service and symlinks — it never executes an unverified binary.
+# Note: the install script itself (get.k3s.io) is still fetched over HTTPS
+# but not checksum-verified; the blast radius is limited to service-file setup.
+
+- name: Check if k3s is already installed at required version
+  ansible.builtin.shell: |
+    /usr/local/bin/k3s --version 2>/dev/null | grep -qF "{{ k3s_version }}"
+  register: _k3s_version_check
+  changed_when: false
+  failed_when: false
+
+- name: Download and verify k3s binary
+  when: _k3s_version_check.rc != 0
+  block:
+    - name: Download k3s binary from GitHub releases
+      ansible.builtin.get_url:
+        url: "https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/k3s"
+        dest: "/tmp/k3s-{{ k3s_version }}"
+        mode: "0755"
+        force: true
+
+    - name: Download k3s SHA256 checksum file
+      ansible.builtin.get_url:
+        url: "https://github.com/k3s-io/k3s/releases/download/{{ k3s_version }}/sha256sum-amd64.txt"
+        dest: "/tmp/k3s-sha256sum-{{ k3s_version }}.txt"
+        mode: "0644"
+        force: true
+
+    - name: Verify k3s binary checksum
+      ansible.builtin.shell: |
+        expected=$(grep ' k3s$' /tmp/k3s-sha256sum-{{ k3s_version }}.txt | awk '{print $1}')
+        actual=$(sha256sum /tmp/k3s-{{ k3s_version }} | awk '{print $1}')
+        if [ "$expected" != "$actual" ]; then
+          echo "k3s checksum mismatch: expected=$expected actual=$actual" >&2
+          exit 1
+        fi
+      changed_when: false
+
+    - name: Install verified k3s binary
+      ansible.builtin.copy:
+        src: "/tmp/k3s-{{ k3s_version }}"
+        dest: /usr/local/bin/k3s
+        mode: "0755"
+        remote_src: true
+
+    - name: Remove k3s install temp files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "/tmp/k3s-{{ k3s_version }}"
+        - "/tmp/k3s-sha256sum-{{ k3s_version }}.txt"

--- a/roles/k3s/tasks/server.yml
+++ b/roles/k3s/tasks/server.yml
@@ -17,13 +17,19 @@
     group: root
     mode: '0644'
 
-- name: Install k3s server
+- name: Download and verify k3s binary
+  ansible.builtin.include_tasks: install.yml
+
+- name: Set up k3s server service
   ansible.builtin.shell: |
-    curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="{{ k3s_version }}" sh -s - server
-  args:
-    creates: /usr/local/bin/k3s
+    curl -sfL https://get.k3s.io | \
+      INSTALL_K3S_VERSION="{{ k3s_version }}" \
+      INSTALL_K3S_SKIP_DOWNLOAD=true \
+      sh -s - server
   environment:
     INSTALL_K3S_EXEC: "server"
+  args:
+    creates: /etc/systemd/system/k3s.service
 
 - name: Wait for k3s server to be ready
   ansible.builtin.wait_for:


### PR DESCRIPTION
Fixes #17.

## Summary
- New `install.yml`: downloads `k3s` binary and `sha256sum-amd64.txt` from GitHub releases for the pinned `k3s_version`, verifies SHA256 before installing, cleans up temp files
- `server.yml` / `agent.yml`: include `install.yml`, then run `get.k3s.io` with `INSTALL_K3S_SKIP_DOWNLOAD=true` so the script only sets up the systemd service and symlinks — no unverified binary ever executes
- Idempotent: `install.yml` skips the download block if the correct version is already installed; service tasks use `creates:` guards

**Residual risk:** `get.k3s.io` is still fetched unverified for service setup. With `INSTALL_K3S_SKIP_DOWNLOAD=true` it can't run a malicious binary, but a compromised script could still write a bad service file. Full elimination would require templating the systemd units directly in Ansible — out of scope for this issue but worth a follow-up.

## Test plan
- [ ] Fresh k3s install on a test node: binary download, checksum verification, and service setup all succeed
- [ ] Re-running the role on an already-installed node: install block is skipped, no changes
- [ ] Intentionally corrupt the checksum file: verify the task fails with a clear mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)