### PR TITLE
Add CI: lint, secret scan, and k3s version check

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,21 @@
+---
+profile: moderate
+
+exclude_paths:
+  - k8s/
+  - scripts/
+  - snippets/
+  - docs/
+  - .github/
+
+skip_list:
+  - yaml[truthy]         # yamllint handles this
+  - name[casing]         # task names are fine mixed-case
+  - no-changed-when      # many shell tasks are genuinely fire-and-forget
+
+warn_list:
+  - package-latest       # Pi-hole uses 'latest' intentionally
+  - command-instead-of-shell
+
+mock_roles: []
+mock_modules: []

--- a/.github/workflows/k3s-version.yml
+++ b/.github/workflows/k3s-version.yml
@@ -1,0 +1,51 @@
+---
+name: k3s version check
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 9am UTC
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check k3s version and checksum URL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read pinned k3s version
+        id: pinned
+        run: |
+          version=$(grep 'k3s_version:' roles/k3s/vars/main.yml | grep -oP '"[^"]+"' | tr -d '"')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Pinned: $version"
+
+      - name: Fetch latest k3s release
+        id: latest
+        run: |
+          latest=$(curl -sf https://api.github.com/repos/k3s-io/k3s/releases/latest \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            | jq -r '.tag_name')
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+          echo "Latest: $latest"
+
+      - name: Verify checksum URL for pinned version
+        run: |
+          url="https://github.com/k3s-io/k3s/releases/download/${{ steps.pinned.outputs.version }}/sha256sum-amd64.txt"
+          status=$(curl -sIo /dev/null -w "%{http_code}" "$url")
+          if [ "$status" != "200" ]; then
+            echo "::error::Checksum URL returned HTTP $status for pinned version ${{ steps.pinned.outputs.version }}"
+            echo "URL: $url"
+            exit 1
+          fi
+          echo "Checksum URL OK ($status)"
+
+      - name: Warn if behind latest
+        run: |
+          pinned="${{ steps.pinned.outputs.version }}"
+          latest="${{ steps.latest.outputs.version }}"
+          if [ "$pinned" != "$latest" ]; then
+            echo "::warning::k3s is behind: pinned=$pinned latest=$latest — update roles/k3s/vars/main.yml when ready to upgrade"
+          else
+            echo "k3s is current: $pinned"
+          fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+---
+name: Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  yamllint:
+    name: yamllint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run yamllint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .yamllint.yml
+          file_or_dir: .
+          strict: false
+
+  ansible-lint:
+    name: ansible-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run ansible-lint
+        uses: ansible/ansible-lint@v24
+        with:
+          args: "--config-file .ansible-lint"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,23 @@
+---
+name: Secret scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        with:
+          config: .gitleaks.toml

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,16 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Ansible Vault encrypted content — intentionally high-entropy"
+regexTarget = "line"
+regexes = ['''ANSIBLE_VAULT''', '''\$ANSIBLE_VAULT''']
+
+[[allowlists]]
+description = "1Password op:// references are URIs, not secrets"
+regexTarget = "line"
+regexes = ['''op://''']
+
+[[allowlists]]
+description = "Sealed secrets are ciphertext encrypted to the cluster public key"
+paths = ['''k8s/secrets/.*-sealed\.yml''']

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,20 @@
+---
+extends: default
+
+rules:
+  line-length:
+    max: 160
+    level: warning
+  truthy:
+    allowed-values: ['true', 'false', 'yes', 'no']
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1
+
+ignore: |
+  roles/*/templates/
+  k8s/secrets/pub-cert.pem
+  passfile.txt


### PR DESCRIPTION
## What's in here

Three workflows + their config files.

**lint.yml** — runs on every push/PR
- `yamllint` via ibiqlik/action-yamllint — checks all YAML in the repo, excludes `roles/*/templates/` (Jinja2, not plain YAML) and the sealed cert
- `ansible-lint` via ansible/ansible-lint — moderate profile, excludes `k8s/`, warns on `package-latest` (Pi-hole uses `latest` tag intentionally)

**secret-scan.yml** — runs on every push/PR  
- `gitleaks` full history scan (`fetch-depth: 0`)
- Allowlisted: Ansible Vault encrypted blocks (intentional high-entropy), `op://` URIs (1Password references, not secrets), sealed secret ciphertext

**k3s-version.yml** — runs Monday 9am UTC + `workflow_dispatch`
- Reads `k3s_version` from `roles/k3s/vars/main.yml`
- Verifies the checksum URL for the pinned version responds 200 (catches deleted/yanked releases)
- Emits a warning annotation if behind latest — not a hard failure, just a nudge

## One thing to know

`gitleaks-action` is free for public repos. For private repos it needs a `GITLEAKS_LICENSE` secret — the free tier works without it but will print a license warning in the logs. Add `GITLEAKS_LICENSE` to repo secrets if you want to suppress that.

## Expected first-run noise

ansible-lint will likely flag some existing issues in the repo (the `no-changed-when` skip handles the most common ones, but there may be others). Treat the first run as a baseline audit — fix what's real, add to `skip_list` what's intentional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)