### PR TITLE
Pin Pi-hole container image to SHA256 digest

### DIFF
--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -143,7 +143,7 @@
   community.docker.docker_container:
     name: pihole
     hostname: pihole
-    image: pihole/pihole:latest
+    image: pihole/pihole@sha256:712b39f1fdb55121cef509813dfbe02d2bdef9c28e07404fa1d422f5157323b2
     restart_policy: unless-stopped
     state: started
     capabilities:


### PR DESCRIPTION
Fixes the Pi-hole half of #11.

Replaces `pihole/pihole:latest` with a pinned SHA256 digest so the container can't silently pull a different image on restart.

**Digest pinned:** `sha256:712b39f1fdb55121cef509813dfbe02d2bdef9c28e07404fa1d422f5157323b2`
**Pulled:** 2026-05-03 (`pihole/pihole:latest`, amd64)

**Mosquitto note:** The issue also references `k8s/apps/homebridge/mosquitto/values.yml` but that manifest doesn't exist yet — Mosquitto isn't deployed to k8s. Pin it when the manifest is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)