### PR TITLE
Add Eddie: cloud automation brain (n8n + LiteLLM + Qdrant + SearXNG on Hetzner k3s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ facts
 passfile.txt
 roles/aistack/files/__pycache__/
 .codevis_cache.json
+
+# Eddie cloud cluster
+.kube/
+vars/eddie_vault.yml

--- a/EDDIE.md
+++ b/EDDIE.md
@@ -1,0 +1,149 @@
+# Eddie — cloud automation brain (Hetzner / Hillsboro)
+
+Eddie is an always-on automation/agent stack running on its own single-node k3s
+cluster at Hetzner (Hillsboro, OR — US-West, closest to home). It is deliberately
+separate from the home cluster so it stays up independent of home power/internet.
+
+**Stack:** n8n (orchestration) + LiteLLM (model router) + Qdrant (vector memory)
++ SearXNG (private search). No GPU — inference goes to Claude and serverless
+open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
+
+> ⚠️ **Status: reviewed scaffolding, not yet applied.** Nothing here has been run
+> against live infrastructure. Treat the first `tofu apply` / `deploy_eddie.yml`
+> as a validation run. Costs ~$18–25/mo (CPX31 + volume) ≈ a few hundred $/year.
+
+## Architecture
+
+```
+                         Internet
+                            │  :443 (Traefik + Let's Encrypt)
+                            ▼
+   eddie.alvani.me ──► [ k3s @ Hetzner Hillsboro, CPX31 ]
+                            │
+        ┌───────────────────┼────────────────────────┐
+        ▼                   ▼                         ▼
+      n8n  ──────────►  LiteLLM  ──────►  Anthropic (claude)
+   (public UI)        (ClusterIP)        Groq / Together (open models)
+        │                                 [future: Mac Mini Ollama]
+        ├──────────►  Qdrant  (ClusterIP, vector memory)
+        └──────────►  SearXNG (ClusterIP, private search)
+```
+
+Only n8n is exposed publicly. LiteLLM/Qdrant/SearXNG are ClusterIP-only.
+
+## Layout
+
+| Path | Purpose |
+|------|---------|
+| `infra/hetzner-eddie/` | OpenTofu — provisions the Hetzner node (server, firewall, volume, SSH key) |
+| `inventory_eddie.yml` | Ansible inventory for the cloud node (fill in the IP) |
+| `deploy_eddie.yml` | Installs k3s + cert-manager + the Eddie apps |
+| `create_eddie_secrets.yml` | Creates k8s Secrets from `vars/eddie_vault.yml` |
+| `vars/eddie.yml` | Non-secret config (hostnames, versions, namespace) |
+| `vars/eddie_vault.yml.example` | Template for the vault-encrypted secrets |
+| `k8s/apps/ai/eddie/*.yml` | bjw-s app-template values: n8n, litellm, qdrant, searxng |
+
+## Why hybrid (OpenTofu + Ansible)
+
+OpenTofu owns the **infra lifecycle** — its state file gives a clean `tofu destroy`
+so teardown never orphans a billable volume/IP, plus drift detection. Ansible owns
+**everything above the OS** (k3s + Helm + apps), which is where your existing
+expertise lives. The OpenTofu surface is intentionally tiny (~5 resources).
+
+## First-time setup
+
+### 0. Prereqs (controller / your machine)
+```bash
+# OpenTofu (or terraform), helm, kubectl
+ansible-galaxy collection install kubernetes.core
+# Hetzner API token: Cloud Console → project → Security → API Tokens (Read & Write)
+```
+
+### 1. Provision the node (OpenTofu)
+```bash
+cd infra/hetzner-eddie
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars: hcloud_token + admin_cidrs (your home IP: curl ifconfig.me)
+tofu init
+tofu apply
+tofu output eddie_ipv4        # note this IP
+cp terraform.tfstate /whidbey/backups/eddie-tfstate-$(date +%F).backup   # back up state!
+```
+
+### 2. DNS
+Create a **public** A record: `eddie.alvani.me → <eddie_ipv4>`.
+
+> **Split-horizon gotcha:** Pi-hole resolves `*.alvani.me → 10.0.1.30` (home Traefik)
+> on the LAN. So on your home network `eddie.alvani.me` would point at the *home*
+> cluster, not Hetzner. Options: (a) use a subdomain carved out of the split-horizon
+> rule, or (b) add a Pi-hole local DNS override for `eddie.alvani.me → <eddie_ipv4>`.
+> Public/mobile resolution is unaffected.
+
+### 3. Point inventory at the node
+Edit `inventory_eddie.yml` → set `ansible_host` to the `eddie_ipv4` output.
+
+### 4. Install k3s + apps
+```bash
+ansible-playbook -i inventory_eddie.yml deploy_eddie.yml
+```
+
+### 5. Create secrets
+```bash
+cp vars/eddie_vault.yml.example vars/eddie_vault.yml
+# Generate values:
+#   openssl rand -hex 32   # n8n encryption key + searxng secret
+#   openssl rand -hex 24   # litellm master key + qdrant api key
+# Add your ANTHROPIC_API_KEY (and optional TOGETHER/GROQ keys).
+ansible-vault encrypt vars/eddie_vault.yml --vault-id fustercluck@passfile.txt
+ansible-playbook -i inventory_eddie.yml create_eddie_secrets.yml --vault-id fustercluck@passfile.txt
+# restart n8n so it picks up the encryption key if it started first:
+KUBECONFIG=.kube/eddie.yaml kubectl -n ai rollout restart deploy
+```
+
+### 6. Open Eddie
+Visit `https://eddie.alvani.me`, create the owner account, and wire workflows.
+Point n8n's AI/HTTP nodes at the in-cluster brain endpoints (already injected as
+`LITELLM_BASE_URL`, `QDRANT_URL`, `SEARXNG_URL` env vars).
+
+## 🔑 The one thing you must not lose
+`vault_n8n_encryption_key` encrypts **every credential n8n stores**. Generate it
+**once**, keep it in the vault, and back it up. Rotate/lose it → all stored n8n
+credentials are unrecoverable. Also back up the node's data volume (Qdrant + n8n
+SQLite live on `/mnt/eddie-data`).
+
+## Day-2
+
+```bash
+# kubectl/helm against Eddie
+export KUBECONFIG=$(pwd)/.kube/eddie.yaml
+kubectl get pods -n ai
+
+# Update an app: edit k8s/apps/ai/eddie/<app>.yml, then re-run
+ansible-playbook -i inventory_eddie.yml deploy_eddie.yml
+
+# Tear it ALL down (stops billing cleanly)
+cd infra/hetzner-eddie && tofu destroy
+```
+
+## Adding a second Eddie
+Copy `k8s/apps/ai/eddie/n8n.yml` → `n8n-work.yml`, change the hostname + PVC,
+add the release name to the loop in `deploy_eddie.yml`. LiteLLM/Qdrant/SearXNG are
+shared — give each Eddie its own Qdrant collection for memory isolation.
+
+## Bringing Eddie home (future)
+The whole point of going k8s-native: migration is cheap. When you want Eddie local —
+e.g. on a **Mac Mini** (Apple Silicon is excellent for local LLMs) — you have two
+moves, independent of each other:
+
+1. **Inference home first (keep Eddie at Hetzner):** run Ollama on the Mac Mini,
+   uncomment the `local` route in `k8s/apps/ai/eddie/litellm.yml`, point `api_base`
+   at the Mac Mini. Eddie keeps asking LiteLLM for model `local`; only the target
+   changes. Zero workflow edits.
+2. **Eddie home fully:** the apps are plain Helm releases — deploy the same
+   `k8s/apps/ai/eddie/*.yml` onto the home cluster (or the Mac Mini's k3s),
+   move DNS, and `tofu destroy` the Hetzner node.
+
+Local inference belongs on the Mac Mini, **not** the 3-Pi cluster (CPU-only ARM,
+already loaded — realistically only 1–3B models / embeddings) and **not** back on
+20-size as-is (NFS lock contention starved Ollama; needs resource isolation first).
+```

--- a/EDDIE.md
+++ b/EDDIE.md
@@ -23,10 +23,14 @@ Most automation is trigger-based and won't need any of this.
 + SearXNG (private search). No GPU — inference goes to Claude and serverless
 open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
 
-> ⚠️ **Status: reviewed scaffolding, not yet applied.** Nothing here has been run
-> against live infrastructure. Treat the first `tofu apply` / `deploy_eddie.yml`
-> as a validation run. Costs ~$8–12/mo (CAX21 arm64 + volume) ≈ ~$100–150/year
-> (x86 cpx31 would be ~$18–25/mo).
+> **Status (2026-06-14):** node provisioned — `cx33` (Intel 4 vCPU/8 GB) in `hel1`
+> (Helsinki), IP `65.108.152.20`, data volume attached. The k3s/app **deploy step
+> has not been run yet**. Cost ~$7–8/mo (cx33 + volume) ≈ ~$100/year.
+>
+> Server-type note: ARM (cax21, ~half price) was **sold out across all Hetzner
+> locations** at provision time, and `fsn1` had no 4c/8g x86 free either — hence
+> `cx33`/`hel1`. Run `infra/hetzner-eddie/check-availability.sh` to re-check; swap
+> to `cax21` whenever ARM capacity returns (data volume persists through it).
 
 ## Architecture
 
@@ -34,7 +38,7 @@ open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
                          Internet
                             │  :443 (Traefik + Let's Encrypt)
                             ▼
-   eddie.alvani.me ──► [ k3s @ Hetzner Helsinki, CAX21 (arm64) ]
+   eddie.alvani.me ──► [ k3s @ Hetzner Helsinki, CX33 (x86) ]
                             │
         ┌───────────────────┼────────────────────────┐
         ▼                   ▼                         ▼

--- a/EDDIE.md
+++ b/EDDIE.md
@@ -23,14 +23,21 @@ Most automation is trigger-based and won't need any of this.
 + SearXNG (private search). No GPU — inference goes to Claude and serverless
 open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
 
-> **Status (2026-06-14):** node provisioned — `cx33` (Intel 4 vCPU/8 GB) in `hel1`
-> (Helsinki), IP `65.108.152.20`, data volume attached. The k3s/app **deploy step
-> has not been run yet**. Cost ~$7–8/mo (cx33 + volume) ≈ ~$100/year.
+> **Status (2026-06-14): LIVE.** `cx33` (Intel 4 vCPU/8 GB) in `hel1` (Helsinki),
+> IP `65.108.152.20`. All four pods Running, Let's Encrypt cert issued, n8n
+> reachable at https://eddie.alvani.me. Cost ~$7–8/mo (cx33 + volume) ≈ ~$100/year.
 >
-> Server-type note: ARM (cax21, ~half price) was **sold out across all Hetzner
-> locations** at provision time, and `fsn1` had no 4c/8g x86 free either — hence
-> `cx33`/`hel1`. Run `infra/hetzner-eddie/check-availability.sh` to re-check; swap
-> to `cax21` whenever ARM capacity returns (data volume persists through it).
+> Provisioning notes for next time:
+> - ARM (cax21, ~half price) was **sold out across all Hetzner locations**, and
+>   `fsn1` had no 4c/8g x86 free either — hence `cx33`/`hel1`. Run
+>   `infra/hetzner-eddie/check-availability.sh` to re-check; swap to `cax21` when
+>   ARM returns (the data volume persists through a server replace).
+> - litellm needs ~1.5 Gi memory (OOMKilled at 512 Mi).
+> - The control node (20-size) needs: ansible + `kubernetes.core` +
+>   `python3-kubernetes` + helm. Use `ANSIBLE_VAULT_IDENTITY_LIST=fustercluck@<file>`
+>   to bypass the `op`-based vault password when running from a host without 1Password.
+> - Diagnostics: `infra/hetzner-eddie/eddie-diag.sh` (secret-free) piped to a paste,
+>   or `--logs` for verbose (treat as sensitive).
 
 ## Architecture
 

--- a/EDDIE.md
+++ b/EDDIE.md
@@ -1,8 +1,23 @@
-# Eddie — cloud automation brain (Hetzner / Hillsboro)
+# Eddie — cloud automation brain (Hetzner / Helsinki)
 
 Eddie is an always-on automation/agent stack running on its own single-node k3s
-cluster at Hetzner (Hillsboro, OR — US-West, closest to home). It is deliberately
-separate from the home cluster so it stays up independent of home power/internet.
+cluster at Hetzner (Helsinki, Finland — EU). It is deliberately separate from the
+home cluster so it stays up independent of home power/internet.
+
+**Why Helsinki (EU) over Hillsboro (US-West):** EU/German jurisdiction. Data on an
+EU Hetzner node falls under GDPR and is shielded from the US CLOUD Act (Hetzner
+Online GmbH has no US parent). The cost is ~150 ms latency to a PNW home — which is
+imperceptible for trigger-based automation. To flip back to US-West, set
+`location = "hil"` in `terraform.tfvars` before applying; nothing else cares.
+
+**If a latency-sensitive workload shows up later** (chatty, multi-round-trip, or
+near-real-time interaction with home devices), we address it *then* rather than
+compromising the whole cluster's jurisdiction now. Options, in order of preference:
+1. Run just that piece on the **home cluster** (kube02/03) — it's the same Helm
+   release; place it where the latency demands. Eddie stays the always-on cloud spine.
+2. Stand up a **second node in `hil`** (Hillsboro) for that workload only.
+3. Push the latency-bound logic to an **edge/webhook relay** at home that Eddie calls.
+Most automation is trigger-based and won't need any of this.
 
 **Stack:** n8n (orchestration) + LiteLLM (model router) + Qdrant (vector memory)
 + SearXNG (private search). No GPU — inference goes to Claude and serverless
@@ -10,7 +25,8 @@ open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
 
 > ⚠️ **Status: reviewed scaffolding, not yet applied.** Nothing here has been run
 > against live infrastructure. Treat the first `tofu apply` / `deploy_eddie.yml`
-> as a validation run. Costs ~$18–25/mo (CPX31 + volume) ≈ a few hundred $/year.
+> as a validation run. Costs ~$8–12/mo (CAX21 arm64 + volume) ≈ ~$100–150/year
+> (x86 cpx31 would be ~$18–25/mo).
 
 ## Architecture
 
@@ -18,7 +34,7 @@ open models via LiteLLM. See "Bringing Eddie home" for the on-prem path.
                          Internet
                             │  :443 (Traefik + Let's Encrypt)
                             ▼
-   eddie.alvani.me ──► [ k3s @ Hetzner Hillsboro, CPX31 ]
+   eddie.alvani.me ──► [ k3s @ Hetzner Helsinki, CAX21 (arm64) ]
                             │
         ┌───────────────────┼────────────────────────┐
         ▼                   ▼                         ▼

--- a/create_eddie_secrets.yml
+++ b/create_eddie_secrets.yml
@@ -1,0 +1,76 @@
+---
+# Create the k8s Secrets the Eddie brain needs, from vault-encrypted values.
+# Mirrors the pattern of create_secrets.yml but targets the Eddie cloud cluster.
+#
+# Run AFTER deploy_eddie.yml (namespace + kubeconfig must exist):
+#   ansible-playbook -i inventory_eddie.yml create_eddie_secrets.yml --vault-id fustercluck@passfile.txt
+#
+# CRITICAL: vault_n8n_encryption_key must be generated ONCE and never changed.
+# It encrypts every credential n8n stores. Lose it or rotate it and all stored
+# credentials become unrecoverable. Generate with: openssl rand -hex 32
+
+- name: Create Eddie secrets
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - vars/eddie.yml
+    - vars/eddie_vault.yml
+  environment:
+    KUBECONFIG: "{{ eddie_kubeconfig_local }}"
+  tasks:
+    - name: n8n secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: n8n-secret
+            namespace: "{{ eddie_namespace }}"
+          type: Opaque
+          stringData:
+            N8N_ENCRYPTION_KEY: "{{ vault_n8n_encryption_key }}"
+
+    - name: LiteLLM secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: litellm-secret
+            namespace: "{{ eddie_namespace }}"
+          type: Opaque
+          stringData:
+            LITELLM_MASTER_KEY: "{{ vault_litellm_master_key }}"
+            ANTHROPIC_API_KEY: "{{ vault_anthropic_api_key }}"
+            # Optional serverless open-model routes — leave blank if unused
+            TOGETHER_API_KEY: "{{ vault_together_api_key | default('') }}"
+            GROQ_API_KEY: "{{ vault_groq_api_key | default('') }}"
+
+    - name: Qdrant secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: qdrant-secret
+            namespace: "{{ eddie_namespace }}"
+          type: Opaque
+          stringData:
+            QDRANT_API_KEY: "{{ vault_qdrant_api_key }}"
+
+    - name: SearXNG secret
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: searxng-secret
+            namespace: "{{ eddie_namespace }}"
+          type: Opaque
+          stringData:
+            SEARXNG_SECRET: "{{ vault_searxng_secret }}"

--- a/deploy_eddie.yml
+++ b/deploy_eddie.yml
@@ -1,0 +1,126 @@
+---
+# Eddie cloud cluster — config + app deploy (the "Ansible" half of the hybrid).
+#
+# Assumes the node already exists (provisioned by infra/hetzner-eddie via OpenTofu)
+# and that inventory_eddie.yml points at its public IP.
+#
+# What it does:
+#   Play 1 (on the node): install single-node k3s, point local-path storage at the
+#           durable data volume, fetch an admin kubeconfig back to the controller.
+#   Play 2 (local):       install cert-manager + a Let's Encrypt issuer, then deploy
+#           the Eddie brain (n8n + LiteLLM + Qdrant + SearXNG) via the bjw-s chart.
+#
+# Run:
+#   ansible-playbook -i inventory_eddie.yml deploy_eddie.yml
+#   # then, once per cluster, load secrets:
+#   ansible-playbook -i inventory_eddie.yml create_eddie_secrets.yml --vault-id fustercluck@passfile.txt
+#
+# Prereqs on the controller: helm, kubectl, and
+#   ansible-galaxy collection install kubernetes.core
+
+- name: Bootstrap k3s on the Eddie node
+  hosts: eddie
+  become: true
+  gather_facts: true
+  vars_files:
+    - vars/eddie.yml
+  tasks:
+    - name: Install single-node k3s
+      ansible.builtin.shell: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server \
+          --write-kubeconfig-mode 644 \
+          --default-local-storage-path {{ eddie_local_storage_path }} \
+          --tls-san {{ ansible_host }}" sh -
+      args:
+        creates: /usr/local/bin/k3s
+
+    - name: Wait for kubeconfig to be written
+      ansible.builtin.wait_for:
+        path: /etc/rancher/k3s/k3s.yaml
+        timeout: 120
+
+    - name: Slurp k3s kubeconfig
+      ansible.builtin.slurp:
+        src: /etc/rancher/k3s/k3s.yaml
+      register: eddie_kubeconfig_raw
+
+    - name: Ensure local .kube directory exists
+      ansible.builtin.file:
+        path: "{{ eddie_kubeconfig_local | dirname }}"
+        state: directory
+        mode: '0700'
+      delegate_to: localhost
+      become: false
+
+    - name: Write kubeconfig to controller (server URL rewritten to public IP)
+      ansible.builtin.copy:
+        # 127.0.0.1 in the in-cluster kubeconfig → the node's public IP so helm/kubectl
+        # work from the controller. Mirrors roles/k3s/tasks/kubeconfig.yml.
+        content: "{{ eddie_kubeconfig_raw.content | b64decode | replace('127.0.0.1', ansible_host) }}"
+        dest: "{{ eddie_kubeconfig_local }}"
+        mode: '0600'
+      delegate_to: localhost
+      become: false
+
+- name: Deploy Eddie brain
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars_files:
+    - vars/eddie.yml
+  environment:
+    KUBECONFIG: "{{ eddie_kubeconfig_local }}"
+  tasks:
+    - name: Create the ai namespace
+      kubernetes.core.k8s:
+        kind: Namespace
+        name: "{{ eddie_namespace }}"
+        state: present
+
+    - name: Install cert-manager (CRDs + controller)
+      kubernetes.core.helm:
+        name: cert-manager
+        chart_ref: cert-manager
+        chart_repo_url: https://charts.jetstack.io
+        release_namespace: cert-manager
+        create_namespace: true
+        chart_version: "{{ eddie_cert_manager_version }}"
+        values:
+          crds:
+            enabled: true
+        wait: true
+
+    - name: Create Let's Encrypt ClusterIssuer (HTTP-01 via Traefik)
+      kubernetes.core.k8s:
+        state: present
+        definition:
+          apiVersion: cert-manager.io/v1
+          kind: ClusterIssuer
+          metadata:
+            name: letsencrypt-issuer
+          spec:
+            acme:
+              server: https://acme-v02.api.letsencrypt.org/directory
+              email: "{{ eddie_acme_email }}"
+              privateKeySecretRef:
+                name: letsencrypt-issuer-account-key
+              solvers:
+                - http01:
+                    ingress:
+                      class: traefik
+
+    # Each Eddie component is one bjw-s app-template release. Adding a second
+    # Eddie later = copy a values file and add an item to this loop.
+    - name: Deploy Eddie components
+      kubernetes.core.helm:
+        name: "{{ item }}"
+        chart_ref: oci://ghcr.io/bjw-s-labs/helm/app-template
+        chart_version: "{{ eddie_app_template_version }}"
+        release_namespace: "{{ eddie_namespace }}"
+        values: "{{ lookup('file', 'k8s/apps/ai/eddie/' + item + '.yml') | from_yaml }}"
+        wait: false
+      loop:
+        - litellm
+        - qdrant
+        - searxng
+        - n8n

--- a/deploy_eddie.yml
+++ b/deploy_eddie.yml
@@ -114,7 +114,7 @@
     - name: Deploy Eddie components
       kubernetes.core.helm:
         name: "{{ item }}"
-        chart_ref: oci://ghcr.io/bjw-s-labs/helm/app-template
+        chart_ref: oci://ghcr.io/bjw-s/helm/app-template
         chart_version: "{{ eddie_app_template_version }}"
         release_namespace: "{{ eddie_namespace }}"
         values: "{{ lookup('file', 'k8s/apps/ai/eddie/' + item + '.yml') | from_yaml }}"

--- a/infra/hetzner-eddie/.gitignore
+++ b/infra/hetzner-eddie/.gitignore
@@ -1,0 +1,7 @@
+# NEVER commit state (may contain secrets) or real tfvars
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+terraform.tfvars
+crash.log

--- a/infra/hetzner-eddie/check-availability.sh
+++ b/infra/hetzner-eddie/check-availability.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Check which Hetzner server types can be created RIGHT NOW, per datacenter.
+# Handy when `tofu apply` fails with `resource_unavailable` or
+# "<type> is unavailable in <loc> and can no longer be ordered" — Hetzner's
+# capacity (especially the cheap ARM CAX line) and per-location plan
+# availability both fluctuate.
+#
+# Token resolution order: $HCLOUD_TOKEN, then $TF_VAR_hcloud_token, then the
+# hcloud_token line in ./terraform.tfvars. The token is never printed.
+#
+# Usage:
+#   cd infra/hetzner-eddie
+#   ./check-availability.sh                      # default 4c/8g candidates
+#   ./check-availability.sh cax21 cx33 cpx32     # specific types
+set -euo pipefail
+
+command -v jq   >/dev/null || { echo "jq is required (sudo apt install jq)"; exit 1; }
+command -v curl >/dev/null || { echo "curl is required"; exit 1; }
+
+TOKEN="${HCLOUD_TOKEN:-${TF_VAR_hcloud_token:-}}"
+if [ -z "$TOKEN" ] && [ -f terraform.tfvars ]; then
+  TOKEN=$(grep -E '^[[:space:]]*hcloud_token' terraform.tfvars | head -1 | cut -d'"' -f2 || true)
+fi
+[ -z "$TOKEN" ] && { echo "No token found (set HCLOUD_TOKEN or put hcloud_token in terraform.tfvars)"; exit 1; }
+
+API="https://api.hetzner.cloud/v1"
+ST=$(curl -s -H "Authorization: Bearer $TOKEN" "$API/server_types?per_page=100")
+DC=$(curl -s -H "Authorization: Bearer $TOKEN" "$API/datacenters?per_page=100")
+
+# Candidate types default to 4 vCPU / 8 GB across the ARM + x86 lines.
+TYPES=("$@")
+[ ${#TYPES[@]} -eq 0 ] && TYPES=(cax21 cax31 cx33 cpx31 cpx32)
+
+for t in "${TYPES[@]}"; do
+  ID=$(echo "$ST" | jq --arg n "$t" '.server_types[]|select(.name==$n).id')
+  if [ -z "$ID" ] || [ "$ID" = "null" ]; then
+    echo "$t: (no such server type)"
+    continue
+  fi
+  specs=$(echo "$ST" | jq -r --arg n "$t" '.server_types[]|select(.name==$n)|"\(.cores)c/\(.memory)g \(.architecture)"')
+  echo "$t  ($specs):"
+  echo "$DC" | jq -r --argjson id "$ID" \
+    '.datacenters[] | "  \(.name): " + (if ([.server_types.available[]|select(.==$id)]|length>0) then "AVAILABLE" else "—" end)'
+done

--- a/infra/hetzner-eddie/cloud-init.yaml.tftpl
+++ b/infra/hetzner-eddie/cloud-init.yaml.tftpl
@@ -1,0 +1,30 @@
+#cloud-config
+# First-boot setup for the Eddie node. Intentionally minimal — everything beyond
+# "a reachable box with an ansible user and a mounted data disk" is Ansible's job.
+
+users:
+  - name: ansible
+    groups: [sudo]
+    shell: /bin/bash
+    sudo: ["ALL=(ALL) NOPASSWD:ALL"]
+    ssh_authorized_keys:
+      - ${ssh_public_key}
+
+package_update: true
+packages:
+  - curl
+
+%{ if has_volume ~}
+# The attached Hetzner volume appears as /dev/disk/by-id/scsi-0HC_Volume_<id>.
+# It is pre-formatted ext4 by OpenTofu. Mount it at /mnt/eddie-data and point
+# k3s's local-path provisioner there (configured by Ansible) so Eddie's data
+# survives a node rebuild.
+runcmd:
+  - mkdir -p /mnt/eddie-data
+  - |
+    VOL=$(ls /dev/disk/by-id/scsi-0HC_Volume_* 2>/dev/null | head -n1)
+    if [ -n "$VOL" ]; then
+      grep -q "/mnt/eddie-data" /etc/fstab || echo "$VOL /mnt/eddie-data ext4 discard,nofail,defaults 0 0" >> /etc/fstab
+      mount -a
+    fi
+%{ endif ~}

--- a/infra/hetzner-eddie/eddie-diag.sh
+++ b/infra/hetzner-eddie/eddie-diag.sh
@@ -1,47 +1,41 @@
 #!/usr/bin/env bash
-# Collect Eddie cluster diagnostics into a file and push it — so cluster state
-# can be reviewed without copy-pasting from a mobile terminal.
+# Eddie diagnostics → STDOUT. Secret-free by DEFAULT, so it's safe to paste
+# publicly (the repo is public). It includes pod status, services, ingress,
+# certificates, events, and `describe` — which shows secret *names* via
+# secretKeyRef but NEVER their values, and the only plaintext env vars in this
+# stack are non-secret service URLs.
 #
-#   ./eddie-diag.sh            # gathers everything, commits, pushes
+# Container LOGS are EXCLUDED by default because they can leak secrets. Pass
+# --logs to include them, and then share that output only through a private
+# channel (not a public paste/repo).
 #
-# The output is committed to infra/hetzner-eddie/diag-output.txt. It does a light
-# redaction pass on key-like strings, but treat it as sensitive: DELETE it after
-# review (a follow-up commit will remove it).
+#   ./eddie-diag.sh | curl -F'file=@-' https://0x0.st     # safe public paste → URL
+#   ./eddie-diag.sh --logs > /tmp/diag.txt                # includes logs; keep PRIVATE
 set -uo pipefail
 export KUBECONFIG="${KUBECONFIG:-$HOME/fustercluck/.kube/eddie.yaml}"
 NS=ai
-OUT="$HOME/fustercluck/infra/hetzner-eddie/diag-output.txt"
+WANT_LOGS=0
+[ "${1:-}" = "--logs" ] && WANT_LOGS=1
 
-# crude redaction: mask sk-... keys and long hex blobs so they don't land in git
-redact() { sed -E 's/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/\1__REDACTED/g; s/\b([A-Fa-f0-9]{8})[A-Fa-f0-9]{24,}\b/\1__REDACTED/g'; }
+echo "### $(date -u) — Eddie diagnostics$([ "$WANT_LOGS" = 1 ] && echo ' (+LOGS — treat as SENSITIVE)' || echo ' (secret-free)')"
+echo
+echo "### pods"
+kubectl get pods -n "$NS" -o wide
+echo
+echo "### svc / ingress / certificate"
+kubectl get svc,ingress,certificate -n "$NS"
+echo
+echo "### events (last 30)"
+kubectl get events -n "$NS" --sort-by=.lastTimestamp 2>/dev/null | tail -30
 
-{
-  echo "### $(date -u) — Eddie diagnostics"
+for pod in $(kubectl get pods -n "$NS" -o name 2>/dev/null); do
   echo
-  echo "### kubectl get pods -o wide"
-  kubectl get pods -n "$NS" -o wide
-  echo
-  echo "### kubectl get svc,ingress,certificate"
-  kubectl get svc,ingress,certificate -n "$NS"
-  echo
-  echo "### recent events"
-  kubectl get events -n "$NS" --sort-by=.lastTimestamp 2>/dev/null | tail -30
-  echo
-  for pod in $(kubectl get pods -n "$NS" -o name 2>/dev/null); do
-    echo "==================== $pod ===================="
-    echo "--- describe (status + events) ---"
-    kubectl describe -n "$NS" "$pod" 2>&1 | sed -n '/^Containers:/,$p' | tail -55
+  echo "==================== $pod ===================="
+  kubectl describe -n "$NS" "$pod" 2>&1 | sed -n '/^Containers:/,$p' | tail -60
+  if [ "$WANT_LOGS" = 1 ]; then
     echo "--- logs (current) ---"
-    kubectl logs -n "$NS" "$pod" --tail=40 2>&1
+    kubectl logs -n "$NS" "$pod" --tail=50 2>&1
     echo "--- logs (previous crash, if any) ---"
-    kubectl logs -n "$NS" "$pod" --previous --tail=40 2>&1
-    echo
-  done
-} 2>&1 | redact > "$OUT"
-
-cd "$HOME/fustercluck" || exit 1
-git add -f "$OUT"
-git commit -q -m "temp: eddie diag snapshot" && {
-  for i in 1 2 3 4; do git push && break || sleep $((2**i)); done
-}
-echo "Done — pushed $OUT"
+    kubectl logs -n "$NS" "$pod" --previous --tail=50 2>&1
+  fi
+done

--- a/infra/hetzner-eddie/eddie-diag.sh
+++ b/infra/hetzner-eddie/eddie-diag.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Collect Eddie cluster diagnostics into a file and push it — so cluster state
+# can be reviewed without copy-pasting from a mobile terminal.
+#
+#   ./eddie-diag.sh            # gathers everything, commits, pushes
+#
+# The output is committed to infra/hetzner-eddie/diag-output.txt. It does a light
+# redaction pass on key-like strings, but treat it as sensitive: DELETE it after
+# review (a follow-up commit will remove it).
+set -uo pipefail
+export KUBECONFIG="${KUBECONFIG:-$HOME/fustercluck/.kube/eddie.yaml}"
+NS=ai
+OUT="$HOME/fustercluck/infra/hetzner-eddie/diag-output.txt"
+
+# crude redaction: mask sk-... keys and long hex blobs so they don't land in git
+redact() { sed -E 's/(sk-[A-Za-z0-9_-]{4})[A-Za-z0-9_-]+/\1__REDACTED/g; s/\b([A-Fa-f0-9]{8})[A-Fa-f0-9]{24,}\b/\1__REDACTED/g'; }
+
+{
+  echo "### $(date -u) — Eddie diagnostics"
+  echo
+  echo "### kubectl get pods -o wide"
+  kubectl get pods -n "$NS" -o wide
+  echo
+  echo "### kubectl get svc,ingress,certificate"
+  kubectl get svc,ingress,certificate -n "$NS"
+  echo
+  echo "### recent events"
+  kubectl get events -n "$NS" --sort-by=.lastTimestamp 2>/dev/null | tail -30
+  echo
+  for pod in $(kubectl get pods -n "$NS" -o name 2>/dev/null); do
+    echo "==================== $pod ===================="
+    echo "--- describe (status + events) ---"
+    kubectl describe -n "$NS" "$pod" 2>&1 | sed -n '/^Containers:/,$p' | tail -55
+    echo "--- logs (current) ---"
+    kubectl logs -n "$NS" "$pod" --tail=40 2>&1
+    echo "--- logs (previous crash, if any) ---"
+    kubectl logs -n "$NS" "$pod" --previous --tail=40 2>&1
+    echo
+  done
+} 2>&1 | redact > "$OUT"
+
+cd "$HOME/fustercluck" || exit 1
+git add -f "$OUT"
+git commit -q -m "temp: eddie diag snapshot" && {
+  for i in 1 2 3 4; do git push && break || sleep $((2**i)); done
+}
+echo "Done — pushed $OUT"

--- a/infra/hetzner-eddie/main.tf
+++ b/infra/hetzner-eddie/main.tf
@@ -1,0 +1,95 @@
+###############################################################################
+# Eddie cloud node — Hetzner infrastructure
+#
+# Provisions exactly five resources (the whole point of using OpenTofu here is a
+# clean `tofu destroy` so a teardown never orphans a billable volume/IP):
+#   1. SSH key      — public key authorized on the node
+#   2. Firewall     — 22/6443 locked to admin_cidrs; 80/443 open for Traefik
+#   3. Volume       — persistent data disk for Eddie's brain (optional)
+#   4. Server       — the k3s node itself (CPX31 in Hillsboro)
+#   5. Volume attach — binds the volume to the server
+#
+# Everything ABOVE the OS (k3s, Helm, Eddie apps) is handled by Ansible — see
+# deploy_eddie.yml. This file stops at "a reachable Ubuntu box with a data disk".
+###############################################################################
+
+resource "hcloud_ssh_key" "eddie" {
+  name       = "${var.server_name}-key"
+  public_key = file(pathexpand(var.ssh_public_key_path))
+  labels     = var.labels
+}
+
+resource "hcloud_firewall" "eddie" {
+  name   = "${var.server_name}-fw"
+  labels = var.labels
+
+  # SSH — admin only
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "22"
+    source_ips = var.admin_cidrs
+  }
+
+  # k3s API — admin only (kubectl/helm from your machine)
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "6443"
+    source_ips = var.admin_cidrs
+  }
+
+  # HTTP/HTTPS — world (Traefik ingress + Let's Encrypt HTTP-01 challenge)
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "80"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+  rule {
+    direction  = "in"
+    protocol   = "tcp"
+    port       = "443"
+    source_ips = ["0.0.0.0/0", "::/0"]
+  }
+}
+
+resource "hcloud_volume" "eddie_data" {
+  count     = var.data_volume_size > 0 ? 1 : 0
+  name      = "${var.server_name}-data"
+  size      = var.data_volume_size
+  location  = var.location
+  format    = "ext4"
+  labels    = var.labels
+}
+
+resource "hcloud_server" "eddie" {
+  name        = var.server_name
+  server_type = var.server_type
+  image       = var.image
+  location    = var.location
+  ssh_keys    = [hcloud_ssh_key.eddie.id]
+  firewall_ids = [hcloud_firewall.eddie.id]
+  labels      = var.labels
+
+  public_net {
+    ipv4_enabled = true
+    ipv6_enabled = true
+  }
+
+  # cloud-init: create the `ansible` user (matches the rest of the repo's remote_user),
+  # authorize the same key, and format/mount the data volume at /mnt/eddie-data so
+  # k3s local-path storage can live on the durable disk. Keeps Ansible's first
+  # connection clean (no root login needed after this).
+  user_data = templatefile("${path.module}/cloud-init.yaml.tftpl", {
+    ssh_public_key = file(pathexpand(var.ssh_public_key_path))
+    has_volume     = var.data_volume_size > 0
+  })
+}
+
+resource "hcloud_volume_attachment" "eddie_data" {
+  count     = var.data_volume_size > 0 ? 1 : 0
+  volume_id = hcloud_volume.eddie_data[0].id
+  server_id = hcloud_server.eddie.id
+  automount = false # handled deterministically in cloud-init by volume id
+}

--- a/infra/hetzner-eddie/main.tf
+++ b/infra/hetzner-eddie/main.tf
@@ -55,22 +55,22 @@ resource "hcloud_firewall" "eddie" {
 }
 
 resource "hcloud_volume" "eddie_data" {
-  count     = var.data_volume_size > 0 ? 1 : 0
-  name      = "${var.server_name}-data"
-  size      = var.data_volume_size
-  location  = var.location
-  format    = "ext4"
-  labels    = var.labels
+  count    = var.data_volume_size > 0 ? 1 : 0
+  name     = "${var.server_name}-data"
+  size     = var.data_volume_size
+  location = var.location
+  format   = "ext4"
+  labels   = var.labels
 }
 
 resource "hcloud_server" "eddie" {
-  name        = var.server_name
-  server_type = var.server_type
-  image       = var.image
-  location    = var.location
-  ssh_keys    = [hcloud_ssh_key.eddie.id]
+  name         = var.server_name
+  server_type  = var.server_type
+  image        = var.image
+  location     = var.location
+  ssh_keys     = [hcloud_ssh_key.eddie.id]
   firewall_ids = [hcloud_firewall.eddie.id]
-  labels      = var.labels
+  labels       = var.labels
 
   public_net {
     ipv4_enabled = true

--- a/infra/hetzner-eddie/outputs.tf
+++ b/infra/hetzner-eddie/outputs.tf
@@ -1,0 +1,24 @@
+###############################################################################
+# Outputs. After `tofu apply`, feed eddie_ipv4 into the Ansible inventory
+# (inventory_eddie.yml) and your DNS A record for the n8n hostname.
+###############################################################################
+
+output "eddie_ipv4" {
+  description = "Public IPv4 of the Eddie node. Point your n8n DNS A record here, and set ansible_host to this in inventory_eddie.yml."
+  value       = hcloud_server.eddie.ipv4_address
+}
+
+output "eddie_ipv6" {
+  description = "Public IPv6 of the Eddie node."
+  value       = hcloud_server.eddie.ipv6_address
+}
+
+output "eddie_status" {
+  description = "Server power/provisioning status."
+  value       = hcloud_server.eddie.status
+}
+
+output "data_volume_device" {
+  description = "Linux device path of the attached data volume (empty if data_volume_size = 0)."
+  value       = var.data_volume_size > 0 ? hcloud_volume.eddie_data[0].linux_device : ""
+}

--- a/infra/hetzner-eddie/preflight.sh
+++ b/infra/hetzner-eddie/preflight.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Eddie pre-deploy preflight — read-only checks, makes no changes.
+# Run from the control node (e.g. 20-size) inside infra/hetzner-eddie/.
+#
+#   ./preflight.sh                 # uses `tofu output eddie_ipv4` for the IP
+#   ./preflight.sh 65.108.152.20   # or pass the IP explicitly
+#
+# Verifies three things before you run deploy_eddie.yml:
+#   1. SERVER   — SSH in as ansible, data volume mounted, OS is Ubuntu
+#   2. DNS      — eddie.alvani.me resolves, and where (warns if it points home)
+#   3. TOOLCHAIN— ansible + kubernetes.core + python kubernetes + helm present
+
+HOST_FQDN="${EDDIE_HOST:-eddie.alvani.me}"
+SSH_KEY="${EDDIE_SSH_KEY:-$HOME/.ssh/eddie}"
+SSH_USER="${EDDIE_SSH_USER:-ansible}"
+
+IP="${1:-}"
+[ -z "$IP" ] && IP="$(tofu output -raw eddie_ipv4 2>/dev/null || true)"
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$1"; }
+warn() { printf '  \033[33m!\033[0m %s\n' "$1"; }
+fail() { printf '  \033[31m✗\033[0m %s\n' "$1"; }
+
+echo "== 1. SERVER ($SSH_USER@${IP:-<unknown>}) =="
+if [ -z "$IP" ]; then
+  fail "No IP (pass one as arg, or run from the dir with tofu state)"
+elif [ ! -f "$SSH_KEY" ]; then
+  fail "SSH key not found at $SSH_KEY (set EDDIE_SSH_KEY=...)"
+else
+  out=$(ssh -i "$SSH_KEY" -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 \
+        "$SSH_USER@$IP" 'whoami; df -h --output=target,size /mnt/eddie-data 2>/dev/null | tail -1; . /etc/os-release; echo "$PRETTY_NAME"' 2>&1)
+  if [ $? -eq 0 ]; then
+    who=$(echo "$out" | sed -n 1p); vol=$(echo "$out" | sed -n 2p); os=$(echo "$out" | sed -n 3p)
+    [ "$who" = "$SSH_USER" ] && pass "SSH login as $who" || warn "logged in as '$who' (expected $SSH_USER)"
+    echo "$vol" | grep -q /mnt/eddie-data && pass "data volume mounted: $vol" || fail "no mount at /mnt/eddie-data"
+    echo "$os" | grep -qi ubuntu && pass "OS: $os" || warn "OS: $os"
+  else
+    fail "SSH failed: $out"
+  fi
+fi
+
+echo "== 2. DNS ($HOST_FQDN) =="
+resolved=$(getent hosts "$HOST_FQDN" | awk '{print $1}' | head -1)
+if [ -z "$resolved" ]; then
+  fail "$HOST_FQDN does not resolve (add the public A record + Pi-hole entry)"
+elif [ -n "$IP" ] && [ "$resolved" = "$IP" ]; then
+  pass "$HOST_FQDN → $resolved (matches server)"
+elif [ "$resolved" = "10.0.1.30" ]; then
+  warn "$HOST_FQDN → $resolved (home Traefik!) — add a Pi-hole override → $IP"
+else
+  warn "$HOST_FQDN → $resolved (expected $IP) — check A record / Pi-hole / propagation"
+fi
+
+echo "== 3. CONTROL-NODE TOOLCHAIN =="
+command -v ansible-playbook >/dev/null && pass "ansible ($(ansible --version 2>/dev/null | head -1))" \
+  || fail "ansible missing  → sudo apt install -y ansible  (or pipx install ansible)"
+if command -v ansible-galaxy >/dev/null && ansible-galaxy collection list 2>/dev/null | grep -q 'kubernetes.core'; then
+  pass "ansible collection kubernetes.core"
+else
+  fail "kubernetes.core missing  → ansible-galaxy collection install kubernetes.core"
+fi
+python3 -c 'import kubernetes' 2>/dev/null && pass "python kubernetes lib" \
+  || fail "python kubernetes missing  → pip install --user kubernetes  (needed by kubernetes.core modules)"
+command -v helm >/dev/null && pass "helm ($(helm version --short 2>/dev/null))" \
+  || fail "helm missing  → curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash"
+command -v kubectl >/dev/null && pass "kubectl present" || warn "kubectl missing (optional; handy for poking the cluster)"
+
+echo
+echo "Fix any ✗ above, then: ansible-playbook -i inventory_eddie.yml deploy_eddie.yml"

--- a/infra/hetzner-eddie/terraform.tfvars.example
+++ b/infra/hetzner-eddie/terraform.tfvars.example
@@ -11,8 +11,8 @@ admin_cidrs = ["YOUR.HOME.IP.HERE/32"]
 
 # Optional overrides (defaults shown):
 # server_name         = "eddie-01"
-# location            = "hil"            # Hillsboro, OR
-# server_type         = "cpx31"          # 4 vCPU / 8 GB
+# location            = "hel1"           # Helsinki, EU (GDPR/jurisdiction). hil = Hillsboro US-West.
+# server_type         = "cax21"          # 4 vCPU / 8 GB ARM (default, ~half price). x86: "cpx31".
 # image               = "ubuntu-24.04"
 # ssh_public_key_path = "~/.ssh/claude_homelab.pub"
 # data_volume_size    = 20               # GB; 0 to disable the durable data disk

--- a/infra/hetzner-eddie/terraform.tfvars.example
+++ b/infra/hetzner-eddie/terraform.tfvars.example
@@ -1,0 +1,18 @@
+# Copy to terraform.tfvars and fill in. terraform.tfvars is gitignored.
+#
+# Get a token: Hetzner Cloud Console → your project → Security → API Tokens →
+# Generate API Token (Read & Write).
+
+hcloud_token = "PASTE_YOUR_HETZNER_API_TOKEN"
+
+# Lock SSH (22) and the k3s API (6443) to your admin IP(s). Find yours: `curl ifconfig.me`.
+# 80/443 are always world-open for Traefik + Let's Encrypt regardless of this.
+admin_cidrs = ["YOUR.HOME.IP.HERE/32"]
+
+# Optional overrides (defaults shown):
+# server_name         = "eddie-01"
+# location            = "hil"            # Hillsboro, OR
+# server_type         = "cpx31"          # 4 vCPU / 8 GB
+# image               = "ubuntu-24.04"
+# ssh_public_key_path = "~/.ssh/claude_homelab.pub"
+# data_volume_size    = 20               # GB; 0 to disable the durable data disk

--- a/infra/hetzner-eddie/terraform.tfvars.example
+++ b/infra/hetzner-eddie/terraform.tfvars.example
@@ -12,7 +12,8 @@ admin_cidrs = ["YOUR.HOME.IP.HERE/32"]
 # Optional overrides (defaults shown):
 # server_name         = "eddie-01"
 # location            = "hel1"           # Helsinki, EU (GDPR/jurisdiction). hil = Hillsboro US-West.
-# server_type         = "cax21"          # 4 vCPU / 8 GB ARM (default, ~half price). x86: "cpx31".
+# server_type         = "cx33"           # Intel 4c/8g EU (~EUR7/mo, default). cax21=ARM (cheaper, often sold out).
+#                                        # availability is per-DC: run ./check-availability.sh if apply fails.
 # image               = "ubuntu-24.04"
-# ssh_public_key_path = "~/.ssh/claude_homelab.pub"
+# ssh_public_key_path = "~/.ssh/eddie.pub"
 # data_volume_size    = 20               # GB; 0 to disable the durable data disk

--- a/infra/hetzner-eddie/variables.tf
+++ b/infra/hetzner-eddie/variables.tf
@@ -1,0 +1,73 @@
+###############################################################################
+# Input variables. Real values go in terraform.tfvars (gitignored).
+# See terraform.tfvars.example for a template.
+###############################################################################
+
+variable "hcloud_token" {
+  description = "Hetzner Cloud API token (Project → Security → API Tokens, Read & Write)."
+  type        = string
+  sensitive   = true
+}
+
+variable "server_name" {
+  description = "Name of the Eddie node in the Hetzner console."
+  type        = string
+  default     = "eddie-01"
+}
+
+variable "location" {
+  description = "Hetzner location. hil = Hillsboro, OR (US-West, closest to home)."
+  type        = string
+  default     = "hil"
+}
+
+variable "server_type" {
+  description = <<-EOT
+    Hetzner server type. CPX31 = 4 vCPU / 8 GB, the smallest comfortable size for
+    the full Eddie brain (n8n + LiteLLM + Qdrant + SearXNG). Note: the cheap CAX
+    (ARM) and CX lines are EU-only — US locations only get CPX/CCX.
+  EOT
+  type        = string
+  default     = "cpx31"
+}
+
+variable "image" {
+  description = "Base OS image."
+  type        = string
+  default     = "ubuntu-24.04"
+}
+
+variable "ssh_public_key_path" {
+  description = "Path to the SSH public key authorized for the root/ansible user on the node."
+  type        = string
+  default     = "~/.ssh/claude_homelab.pub"
+}
+
+variable "admin_cidrs" {
+  description = <<-EOT
+    Source CIDRs allowed to reach SSH (22) and the k3s API (6443). Lock this to
+    your home/admin IP(s) — do NOT leave it open to the world. Example:
+    ["203.0.113.4/32"]. 80/443 stay open to the world for Traefik/Let's Encrypt.
+  EOT
+  type        = list(string)
+}
+
+variable "data_volume_size" {
+  description = <<-EOT
+    Size (GB) of the attached Hetzner volume used for persistent app data
+    (n8n DB + encryption-bound data, Qdrant). Keeping data on a separate volume
+    means the node can be rebuilt without losing Eddie's brain. 0 = no volume
+    (data lives on the node disk; lost on rebuild).
+  EOT
+  type        = number
+  default     = 20
+}
+
+variable "labels" {
+  description = "Labels applied to all Hetzner resources for grouping/billing."
+  type        = map(string)
+  default = {
+    project = "eddie"
+    managed = "opentofu"
+  }
+}

--- a/infra/hetzner-eddie/variables.tf
+++ b/infra/hetzner-eddie/variables.tf
@@ -30,14 +30,16 @@ variable "location" {
 
 variable "server_type" {
   description = <<-EOT
-    Hetzner server type. Default CAX21 = 4 vCPU / 8 GB (arm64) — the EU (hel1)
-    ARM line, ~half the price of x86 with 20 TB bandwidth, comfortably runs the
-    full Eddie brain (n8n + LiteLLM + Qdrant + SearXNG). All images are multi-arch
-    (n8n, Qdrant, SearXNG, and the GHCR LiteLLM image all publish arm64).
-    Prefer x86? Set this to "cpx31" (4 vCPU / 8 GB).
+    Hetzner server type. Default CX33 = 4 vCPU / 8 GB (x86, Intel, EU cost-optimized,
+    ~EUR7/mo) — comfortably runs the full Eddie brain (n8n + LiteLLM + Qdrant +
+    SearXNG). The cheaper ARM line (cax21) is ~half price BUT was sold out across
+    ALL Hetzner locations when this was provisioned (Jun 2026); check current
+    availability with ./check-availability.sh before trying it. Note: server-type
+    availability is per-datacenter — fsn1 had no 4c/8g types free; hel1/nbg1 did.
+    All Eddie images are multi-arch, so cax21 works whenever capacity returns.
   EOT
   type        = string
-  default     = "cax21"
+  default     = "cx33"
 }
 
 variable "image" {

--- a/infra/hetzner-eddie/variables.tf
+++ b/infra/hetzner-eddie/variables.tf
@@ -16,19 +16,28 @@ variable "server_name" {
 }
 
 variable "location" {
-  description = "Hetzner location. hil = Hillsboro, OR (US-West, closest to home)."
+  description = <<-EOT
+    Hetzner location. hel1 = Helsinki, Finland (EU). Chosen for EU/German
+    jurisdiction — data stored here falls under GDPR and is shielded from the US
+    CLOUD Act (Hetzner Online GmbH has no US parent). Tradeoff vs the US options
+    (hil = Hillsboro / ash = Ashburn): ~150 ms latency to a PNW home, which is
+    imperceptible for trigger-based automation. EU locations also unlock the
+    cheaper ARM (CAX) server types — see server_type.
+  EOT
   type        = string
-  default     = "hil"
+  default     = "hel1"
 }
 
 variable "server_type" {
   description = <<-EOT
-    Hetzner server type. CPX31 = 4 vCPU / 8 GB, the smallest comfortable size for
-    the full Eddie brain (n8n + LiteLLM + Qdrant + SearXNG). Note: the cheap CAX
-    (ARM) and CX lines are EU-only — US locations only get CPX/CCX.
+    Hetzner server type. Default CAX21 = 4 vCPU / 8 GB (arm64) — the EU (hel1)
+    ARM line, ~half the price of x86 with 20 TB bandwidth, comfortably runs the
+    full Eddie brain (n8n + LiteLLM + Qdrant + SearXNG). All images are multi-arch
+    (n8n, Qdrant, SearXNG, and the GHCR LiteLLM image all publish arm64).
+    Prefer x86? Set this to "cpx31" (4 vCPU / 8 GB).
   EOT
   type        = string
-  default     = "cpx31"
+  default     = "cax21"
 }
 
 variable "image" {

--- a/infra/hetzner-eddie/versions.tf
+++ b/infra/hetzner-eddie/versions.tf
@@ -1,0 +1,27 @@
+###############################################################################
+# Eddie cloud cluster — provider + backend pinning
+#
+# Tooling: OpenTofu (drop-in Terraform replacement). All commands below work
+# with either `tofu` or `terraform`, but the open-source `tofu` binary is the
+# house default — fits the self-host/open ethos of the rest of this repo.
+#
+# State: kept LOCAL (terraform.tfstate in this dir, gitignored). It can contain
+# secrets, so it is NEVER committed. Back it up to /whidbey/backups after every
+# apply (see README). If you outgrow local state, switch to an S3-compatible
+# backend (Hetzner Object Storage works) — but local is fine for one operator.
+###############################################################################
+
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = "~> 1.49"
+    }
+  }
+}
+
+provider "hcloud" {
+  token = var.hcloud_token
+}

--- a/inventory_eddie.yml
+++ b/inventory_eddie.yml
@@ -1,0 +1,21 @@
+---
+# Separate inventory for the Eddie cloud node (Hetzner / Hillsboro).
+# Kept apart from inventory.yml because this host is NOT on the LAN, uses a
+# public IP (not mDNS .local), and is reached as the `ansible` user created by
+# cloud-init.
+#
+# Fill in ansible_host with the `eddie_ipv4` output from:
+#   cd infra/hetzner-eddie && tofu output eddie_ipv4
+#
+# Usage:
+#   ansible-playbook -i inventory_eddie.yml deploy_eddie.yml
+#   ansible-playbook -i inventory_eddie.yml create_eddie_secrets.yml --vault-id fustercluck@passfile.txt
+
+eddie:
+  hosts:
+    eddie-01:
+      ansible_host: REPLACE_WITH_TOFU_OUTPUT_eddie_ipv4
+  vars:
+    ansible_user: ansible
+    ansible_ssh_private_key_file: ~/.ssh/claude_homelab
+    ansible_python_interpreter: /usr/bin/python3

--- a/inventory_eddie.yml
+++ b/inventory_eddie.yml
@@ -1,10 +1,10 @@
 ---
-# Separate inventory for the Eddie cloud node (Hetzner / Hillsboro).
+# Separate inventory for the Eddie cloud node (Hetzner / Helsinki).
 # Kept apart from inventory.yml because this host is NOT on the LAN, uses a
 # public IP (not mDNS .local), and is reached as the `ansible` user created by
 # cloud-init.
 #
-# Fill in ansible_host with the `eddie_ipv4` output from:
+# ansible_host is the `eddie_ipv4` output from:
 #   cd infra/hetzner-eddie && tofu output eddie_ipv4
 #
 # Usage:
@@ -14,8 +14,9 @@
 eddie:
   hosts:
     eddie-01:
-      ansible_host: REPLACE_WITH_TOFU_OUTPUT_eddie_ipv4
+      ansible_host: 65.108.152.20
   vars:
     ansible_user: ansible
-    ansible_ssh_private_key_file: ~/.ssh/claude_homelab
+    # dedicated keypair generated on the control node for the Eddie server
+    ansible_ssh_private_key_file: ~/.ssh/eddie
     ansible_python_interpreter: /usr/bin/python3

--- a/k8s/apps/ai/eddie/README.md
+++ b/k8s/apps/ai/eddie/README.md
@@ -1,0 +1,16 @@
+# Eddie app values
+
+bjw-s/app-template values for the Eddie cloud brain. Deployed by `deploy_eddie.yml`
+onto the Hetzner k3s cluster (namespace `ai`).
+
+| File | Component | Exposure |
+|------|-----------|----------|
+| `n8n.yml` | n8n — the automation engine (Eddie itself) | Public via Traefik (`eddie.alvani.me`) |
+| `litellm.yml` | LiteLLM — model router (claude + open models) | ClusterIP |
+| `qdrant.yml` | Qdrant — vector memory | ClusterIP |
+| `searxng.yml` | SearXNG — private search | ClusterIP |
+
+Full setup, DNS, secrets, and teardown: see [`/EDDIE.md`](../../../../EDDIE.md).
+
+**Before applying:** pin the `latest` image tags (n8n, qdrant, searxng) to specific
+releases for reproducible rebuilds.

--- a/k8s/apps/ai/eddie/litellm.yml
+++ b/k8s/apps/ai/eddie/litellm.yml
@@ -1,0 +1,127 @@
+# Chart: bjw-s/app-template
+# LiteLLM — model router / OpenAI-compatible proxy for Eddie.
+# Internal only (ClusterIP). Eddie (n8n) calls it at:
+#   http://litellm.ai.svc.cluster.local:4000
+#
+# DB-less by design (store_model_in_db: False) — no Postgres needed for routing.
+#
+# Model routes exposed to Eddie:
+#   claude      → Anthropic (the hard 5%)
+#   open-fast   → Groq Llama 3.3 70B (cheap/fast serverless open model)
+#   open-large  → Together Llama 3.3 70B (serverless open model)
+#   local       → (commented) FUTURE on-prem inference. When you bring Eddie home
+#                 on a Mac Mini, uncomment and point api_base at its Ollama. Eddie
+#                 keeps asking for model "local" — only the target changes. No
+#                 workflow edits required.
+
+controllers:
+  litellm:
+    containers:
+      main:
+        image:
+          repository: ghcr.io/berriai/litellm
+          tag: main-latest
+        args:
+          - "--config"
+          - "/etc/litellm/config.yaml"
+          - "--port"
+          - "4000"
+        env:
+          LITELLM_MASTER_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secret
+                key: LITELLM_MASTER_KEY
+          ANTHROPIC_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secret
+                key: ANTHROPIC_API_KEY
+          TOGETHER_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secret
+                key: TOGETHER_API_KEY
+          GROQ_API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: litellm-secret
+                key: GROQ_API_KEY
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health/liveliness
+                port: 4000
+              initialDelaySeconds: 20
+              periodSeconds: 20
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /health/readiness
+                port: 4000
+              initialDelaySeconds: 10
+              periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 512Mi
+
+configMaps:
+  config:
+    enabled: true
+    data:
+      config.yaml: |-
+        model_list:
+          - model_name: claude
+            litellm_params:
+              model: anthropic/claude-sonnet-4-6
+              api_key: os.environ/ANTHROPIC_API_KEY
+
+          - model_name: open-fast
+            litellm_params:
+              model: groq/llama-3.3-70b-versatile
+              api_key: os.environ/GROQ_API_KEY
+
+          - model_name: open-large
+            litellm_params:
+              model: together_ai/meta-llama/Llama-3.3-70B-Instruct-Turbo
+              api_key: os.environ/TOGETHER_API_KEY
+
+          # FUTURE — on-prem inference (Mac Mini / GPU box brought home).
+          # Uncomment and set api_base to the box's Ollama endpoint.
+          # - model_name: local
+          #   litellm_params:
+          #     model: ollama_chat/llama3.1:8b
+          #     api_base: http://10.0.1.XX:11434
+          #     num_ctx: 8192
+
+        litellm_settings:
+          drop_params: True
+
+        general_settings:
+          master_key: os.environ/LITELLM_MASTER_KEY
+          store_model_in_db: False
+
+service:
+  main:
+    controller: litellm
+    ports:
+      http:
+        port: 4000
+
+persistence:
+  config:
+    enabled: true
+    type: configMap
+    identifier: config
+    globalMounts:
+      - path: /etc/litellm/config.yaml
+        subPath: config.yaml

--- a/k8s/apps/ai/eddie/litellm.yml
+++ b/k8s/apps/ai/eddie/litellm.yml
@@ -55,8 +55,9 @@ controllers:
               httpGet:
                 path: /health/liveliness
                 port: 4000
-              initialDelaySeconds: 20
+              initialDelaySeconds: 60
               periodSeconds: 20
+              failureThreshold: 6
           readiness:
             enabled: true
             custom: true
@@ -64,15 +65,15 @@ controllers:
               httpGet:
                 path: /health/readiness
                 port: 4000
-              initialDelaySeconds: 10
+              initialDelaySeconds: 30
               periodSeconds: 10
         resources:
           requests:
-            cpu: 50m
-            memory: 256Mi
+            cpu: 100m
+            memory: 512Mi
           limits:
             cpu: 1000m
-            memory: 512Mi
+            memory: 1536Mi
 
 configMaps:
   config:

--- a/k8s/apps/ai/eddie/n8n.yml
+++ b/k8s/apps/ai/eddie/n8n.yml
@@ -1,0 +1,103 @@
+# Chart: bjw-s/app-template
+# n8n — Eddie itself: the always-on visual workflow/automation engine.
+# Public via Traefik + Let's Encrypt at https://eddie.alvani.me
+#
+# Storage: SQLite on a local-path PVC backed by the durable Hetzner volume.
+# Fine for a single instance. Switch DB_TYPE to postgresdb later if Eddie grows.
+#
+# Brain wiring (in-cluster, no public exposure of these):
+#   LiteLLM  → http://litellm.ai.svc.cluster.local:4000   (OpenAI-compatible)
+#   Qdrant   → http://qdrant.ai.svc.cluster.local:6333
+#   SearXNG  → http://searxng.ai.svc.cluster.local:8080
+#
+# A second Eddie = copy this file (e.g. n8n-work.yml), change the release name in
+# deploy_eddie.yml's loop, the hostname, and the PVC — shared LiteLLM/Qdrant/SearXNG.
+#
+# NOTE: keep the hostname here in sync with eddie_n8n_host in vars/eddie.yml.
+
+controllers:
+  n8n:
+    containers:
+      main:
+        image:
+          repository: docker.n8n.io/n8nio/n8n
+          tag: latest # PIN to a release: https://github.com/n8n-io/n8n/releases
+        env:
+          N8N_ENCRYPTION_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: n8n-secret
+                key: N8N_ENCRYPTION_KEY
+          N8N_HOST: eddie.alvani.me
+          N8N_PORT: "5678"
+          N8N_PROTOCOL: https
+          WEBHOOK_URL: https://eddie.alvani.me/
+          N8N_EDITOR_BASE_URL: https://eddie.alvani.me/
+          GENERIC_TIMEZONE: America/Los_Angeles
+          # Behind Traefik: trust one proxy hop, keep secure cookies on.
+          N8N_PROXY_HOPS: "1"
+          N8N_SECURE_COOKIE: "true"
+          # Convenience: brain endpoints available to workflows as env vars
+          LITELLM_BASE_URL: http://litellm.ai.svc.cluster.local:4000
+          QDRANT_URL: http://qdrant.ai.svc.cluster.local:6333
+          SEARXNG_URL: http://searxng.ai.svc.cluster.local:8080
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 5678
+              initialDelaySeconds: 30
+              periodSeconds: 20
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 5678
+              initialDelaySeconds: 15
+              periodSeconds: 10
+        resources:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 1500m
+            memory: 1Gi
+
+service:
+  main:
+    controller: n8n
+    ports:
+      http:
+        port: 5678
+
+ingress:
+  main:
+    className: traefik
+    annotations:
+      cert-manager.io/cluster-issuer: letsencrypt-issuer
+    hosts:
+      - host: eddie.alvani.me
+        paths:
+          - path: /
+            pathType: Prefix
+            service:
+              identifier: main
+              port: http
+    tls:
+      - secretName: eddie-tls
+        hosts:
+          - eddie.alvani.me
+
+persistence:
+  data:
+    enabled: true
+    storageClass: local-path
+    accessMode: ReadWriteOnce
+    size: 5Gi
+    globalMounts:
+      - path: /home/node/.n8n

--- a/k8s/apps/ai/eddie/qdrant.yml
+++ b/k8s/apps/ai/eddie/qdrant.yml
@@ -1,0 +1,66 @@
+# Chart: bjw-s/app-template
+# Qdrant — vector memory for Eddie (RAG / long-term memory).
+# Internal only (ClusterIP). Reachable at:
+#   http://qdrant.ai.svc.cluster.local:6333   (REST)
+#   qdrant.ai.svc.cluster.local:6334          (gRPC)
+# API key required even internally (defense in depth) — present it as the
+# `api-key` header from n8n's Qdrant credential.
+
+controllers:
+  qdrant:
+    containers:
+      main:
+        image:
+          repository: qdrant/qdrant
+          tag: latest # pin to a release tag (e.g. v1.x.y) for reproducible rebuilds
+        env:
+          QDRANT__SERVICE__API_KEY:
+            valueFrom:
+              secretKeyRef:
+                name: qdrant-secret
+                key: QDRANT_API_KEY
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 6333
+              initialDelaySeconds: 15
+              periodSeconds: 20
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /readyz
+                port: 6333
+              initialDelaySeconds: 10
+              periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 256Mi
+          limits:
+            cpu: 1000m
+            memory: 1Gi
+
+service:
+  main:
+    controller: qdrant
+    ports:
+      http:
+        port: 6333
+      grpc:
+        port: 6334
+
+persistence:
+  data:
+    enabled: true
+    # local-path PVC backed by the durable Hetzner volume (see deploy_eddie.yml)
+    storageClass: local-path
+    accessMode: ReadWriteOnce
+    size: 5Gi
+    globalMounts:
+      - path: /qdrant/storage

--- a/k8s/apps/ai/eddie/searxng.yml
+++ b/k8s/apps/ai/eddie/searxng.yml
@@ -1,0 +1,80 @@
+# Chart: bjw-s/app-template
+# SearXNG — private metasearch for Eddie's web-search steps.
+# Internal only (ClusterIP). Reachable at:
+#   http://searxng.ai.svc.cluster.local:8080
+# JSON output format is enabled so n8n's HTTP node can parse results
+# (the stock image ships HTML-only).
+
+controllers:
+  searxng:
+    containers:
+      main:
+        image:
+          repository: searxng/searxng
+          tag: latest # pin to a dated tag for reproducible rebuilds
+        env:
+          SEARXNG_BASE_URL: "http://searxng.ai.svc.cluster.local:8080/"
+          SEARXNG_SECRET:
+            valueFrom:
+              secretKeyRef:
+                name: searxng-secret
+                key: SEARXNG_SECRET
+        probes:
+          liveness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              initialDelaySeconds: 15
+              periodSeconds: 20
+          readiness:
+            enabled: true
+            custom: true
+            spec:
+              httpGet:
+                path: /healthz
+                port: 8080
+              initialDelaySeconds: 10
+              periodSeconds: 10
+        resources:
+          requests:
+            cpu: 50m
+            memory: 128Mi
+          limits:
+            cpu: 500m
+            memory: 512Mi
+
+configMaps:
+  settings:
+    enabled: true
+    data:
+      settings.yml: |-
+        use_default_settings: true
+        server:
+          # secret_key is overridden at runtime by the SEARXNG_SECRET env var
+          secret_key: "overridden-by-env"
+          limiter: false
+          image_proxy: true
+        search:
+          # JSON required for programmatic use from n8n
+          formats:
+            - html
+            - json
+
+service:
+  main:
+    controller: searxng
+    ports:
+      http:
+        port: 8080
+
+persistence:
+  settings:
+    enabled: true
+    type: configMap
+    identifier: settings
+    globalMounts:
+      - path: /etc/searxng/settings.yml
+        subPath: settings.yml

--- a/vars/eddie.yml
+++ b/vars/eddie.yml
@@ -1,0 +1,24 @@
+---
+# Non-secret config for the Eddie cloud cluster. Secrets live in
+# vars/eddie_vault.yml (vault-encrypted) and are turned into k8s Secrets by
+# create_eddie_secrets.yml. See vars/eddie_vault.yml.example.
+
+# Kubernetes
+eddie_namespace: ai
+eddie_kubeconfig_local: "{{ playbook_dir }}/.kube/eddie.yaml" # gitignored
+eddie_local_storage_path: /mnt/eddie-data/local-path          # the durable Hetzner volume
+
+# Chart / component versions (pin everything for reproducible rebuilds)
+eddie_app_template_version: "3.6.1"     # bjw-s/app-template (matches k8s/apps house standard)
+eddie_cert_manager_version: "v1.16.2"
+
+# TLS / DNS
+# Public hostname for the n8n UI + webhooks. A public DNS A record for this name
+# MUST point at the node's eddie_ipv4. Use a subdomain that is NOT shadowed by
+# Pi-hole's split-horizon *.alvani.me → 10.0.1.30 rule at home (otherwise it
+# resolves to the home cluster on the LAN). See EDDIE.md.
+eddie_n8n_host: eddie.alvani.me
+eddie_acme_email: jehan@jehanalvani.com
+
+# Timezone for n8n cron triggers
+eddie_timezone: America/Los_Angeles

--- a/vars/eddie_vault.yml.example
+++ b/vars/eddie_vault.yml.example
@@ -1,0 +1,31 @@
+---
+# TEMPLATE — copy to vars/eddie_vault.yml and encrypt:
+#   cp vars/eddie_vault.yml.example vars/eddie_vault.yml
+#   # fill in real values, then:
+#   ansible-vault encrypt vars/eddie_vault.yml --vault-id fustercluck@passfile.txt
+#
+# Or encrypt individual values inline with:
+#   ansible-vault encrypt_string --vault-id fustercluck@passfile.txt 'value' --name 'var_name'
+#
+# vars/eddie_vault.yml is gitignored. This .example file is safe to commit.
+
+# n8n: encrypts ALL stored credentials. Generate ONCE, never change.
+#   openssl rand -hex 32
+vault_n8n_encryption_key: "GENERATE_WITH_openssl_rand_hex_32"
+
+# LiteLLM proxy auth (clients present this as the API key). openssl rand -hex 24
+vault_litellm_master_key: "sk-GENERATE_A_RANDOM_STRING"
+
+# Anthropic API key for the `claude` route (console.anthropic.com)
+vault_anthropic_api_key: "sk-ant-..."
+
+# Optional: serverless open-model providers (leave as empty string if unused)
+vault_together_api_key: ""
+vault_groq_api_key: ""
+
+# Qdrant API key (protects the vector DB even though it's ClusterIP-only).
+#   openssl rand -hex 24
+vault_qdrant_api_key: "GENERATE_A_RANDOM_STRING"
+
+# SearXNG instance secret. openssl rand -hex 32
+vault_searxng_secret: "GENERATE_WITH_openssl_rand_hex_32"


### PR DESCRIPTION
## Eddie — always-on cloud automation brain

Adds **Eddie**, a self-hosted automation/agent stack on its own single-node k3s
cluster at Hetzner (Helsinki / EU, for GDPR + CLOUD-Act-shielded jurisdiction).
Deliberately separate from the home cluster so it stays up independent of home
power/internet. Now **live** at https://eddie.alvani.me.

### Stack
- **n8n** — the always-on visual workflow engine (public via Traefik + Let's Encrypt)
- **LiteLLM** — model router (Claude route + commented stub for future on-prem/Mac-Mini inference)
- **Qdrant** — vector memory
- **SearXNG** — private search
- No GPU; inference is API-based. ~$7–8/mo (cx33 + 20 GB volume).

### Approach — hybrid IaC
- **OpenTofu** (`infra/hetzner-eddie/`) provisions the node, firewall, durable
  data volume, SSH key — clean `tofu destroy`, no orphaned billable resources.
- **Ansible** (`deploy_eddie.yml`) installs k3s + cert-manager + Let's Encrypt,
  then deploys the four apps via the bjw-s app-template chart (matching
  `deploy_apps.yml` conventions). `create_eddie_secrets.yml` loads secrets.

### Files
- `infra/hetzner-eddie/` — OpenTofu config + `check-availability.sh` + `preflight.sh` + `eddie-diag.sh`
- `k8s/apps/ai/eddie/` — bjw-s values: n8n, litellm, qdrant, searxng
- `deploy_eddie.yml`, `create_eddie_secrets.yml`, `inventory_eddie.yml`
- `vars/eddie.yml` (non-secret), `vars/eddie_vault.yml.example` (template; real file gitignored)
- `EDDIE.md` — full runbook: setup, DNS split-horizon note, teardown, multi-Eddie, bring-it-home path

### Notes / provisioning lessons (in EDDIE.md)
- ARM (cax21) was sold out cluster-wide and `fsn1` had no 4c/8g x86 free → landed on `cx33`/`hel1`.
- litellm needs ~1.5 Gi (OOMKilled at 512 Mi).
- Secrets stay local/gitignored; repo is public by design (homelab branding).

https://claude.ai/code/session_01AUHMR4bm3h4LnfEHYJhJEr

---
_Generated by [Claude Code](https://claude.ai/code/session_01AUHMR4bm3h4LnfEHYJhJEr)_